### PR TITLE
use hashicorp/tls to gen bootstrap ssh key

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -24,29 +24,6 @@ provider "registry.opentofu.org/cloudflare/cloudflare" {
   ]
 }
 
-provider "registry.opentofu.org/daveadams/sshkey" {
-  version     = "0.2.1"
-  constraints = "0.2.1"
-  hashes = [
-    "h1:ALlh6Teth+wUs0dA/t55ix2mxbmsUXnO/OXH9MZnEHI=",
-    "zh:144ddb66c13938a5c4e19477706ea384aac8d9f7021e2ab587da80271c6b72ea",
-    "zh:148ea4d9117897e019bb24ad07580370f7394c1a54d148e54a4f096920b589f2",
-    "zh:20a15c8e8ed2a30a8aab313072a353fa376c089d373ac093dd5878f9f4865967",
-    "zh:37e04fb855cff064fa7c82138024ee5a2ddb313f62fb3979244d1216045fd963",
-    "zh:4e683422e3db0d38ae587c4ce02ec7a80f747721748be6794ac506908a3786b5",
-    "zh:4f0e9bb0ce4298c5418ce33e990bea5d286320a552e1055ef041388f88c64711",
-    "zh:6600821042870d79977c9fadc3f98ba25317577a609b884a79d63468c2ebbfc4",
-    "zh:79f7bc6830c935fee39a73d548b42704d00b7d14c7dd28faa01f57914b3804b4",
-    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:a42142309bfcc6d78e74520b8646a2ea2a48e58c848c260b1f5dac7870fbaa3a",
-    "zh:ad471d67e422ae910d727797902123a2f864084abfb8d53b70a655c684eccc44",
-    "zh:b874fc25c5ca86a375b4e4acc78bfa792d1f9352140f53c483413f13aeb00808",
-    "zh:c6ed110814343bd0e94ee691b8524497e42b5b7cdb0095f313f7493bee81aded",
-    "zh:e17cf91342caae909b43c2cd73b4e8c5c8bd55912eb3becbde8c44f6f0164923",
-    "zh:eceb58da244e5e43836fac0f1abb4cccd028f109b5d5536d62c9484898189f8a",
-  ]
-}
-
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.39.0"
   constraints = "5.39.0"
@@ -66,19 +43,19 @@ provider "registry.opentofu.org/hashicorp/aws" {
 }
 
 provider "registry.opentofu.org/hashicorp/external" {
-  version = "2.3.3"
+  version = "2.3.4"
   hashes = [
-    "h1:bDJy8Mj5PMTEuxm6Wu9A9dATBL+mQDmHx8NnLzjvCcc=",
-    "zh:1ec36864a1872abdfd1c53ba3c6837407564ac0d86ab80bf4fdc87b41106fe68",
-    "zh:2117e0edbdc88f0d22fe02fe6b2cfbbbc5d5ce40f8f58e484d8d77d64dd7340f",
-    "zh:4bcfdacd8e2508c16e131de9072cecd359e0ade3b8c6798a049883f37a5872ea",
-    "zh:4da71bc601a37bf8b7413c142d43f5f28e97e531d4836ee8624f41b9fb62e250",
-    "zh:55b9eebac79a46f88db5615f1ee0ac4c3f9351caa4eb8542171ef5d87de60338",
-    "zh:74d64afaef190321f8ddf1c4a9c6489d6cf51098704a2456c1553406e8306328",
-    "zh:8a357e51a0ec69872fafc64da3c6a1039277d325255ef5a264b727d83995d18b",
-    "zh:aacd2e6c13fe19115d51cd28a40a28da017bb48c2e18dec4460d1c37506b1495",
-    "zh:e19c8bdf0e059341d008a50f9138c44009e9ebb3a8047a300e6bc63ed8af8ea0",
-    "zh:fafa9639d8b8402e35f3864c6cfb0762ec57cc365a8f383e2acf81105b1b9eea",
+    "h1:saRbzhRhYh4urj+ARe8vIB0mlRspy6E/fPSyvwqjUW8=",
+    "zh:0e5eb3513d6ad5cc3196799a6e413c6a9c0b642ba6d8f84fc11efa48f58358a4",
+    "zh:1658beae42b4614d4009a3191710c86571ccf1dc526c4bac520a87ab701dd2e9",
+    "zh:28d937c13e90c170fc1e4b726a9bcf113aade53b95b3eccd335cd9eaba8acff5",
+    "zh:2ac19917bb83233f24391d4cbaf301bb6ec14013d3b7f93bdf64823280622daa",
+    "zh:3263d1808fc5252d586a9aa98d89086c912f53e1a3dc43bc5306364b358f04fa",
+    "zh:463469836637342495e22a936ef9ab3c8ab2fb47eb0fae09c346d63f3331af59",
+    "zh:53398a27492cd11f61b2f24c2601c12f50c39da32b90fd25aed7011a1e25a225",
+    "zh:5a44cfbcef52fd3c970144a69a934cab320bd3bb57939ae4682fc516783e2996",
+    "zh:65edb579d9d0dac42e77728d81da6e85ea30d3fe8f2cb6e5db82602ee8afa17e",
+    "zh:f2edd3027b7ae0d31a690fd5dcdcd22b467b4f1e045f84f2bc88289353ef9a5b",
   ]
 }
 
@@ -101,19 +78,19 @@ provider "registry.opentofu.org/hashicorp/nomad" {
 }
 
 provider "registry.opentofu.org/hashicorp/null" {
-  version = "3.2.2"
+  version = "3.2.3"
   hashes = [
-    "h1:xN1tSeF/rUBfaddk/AVqk4i65z/MMM9uVZWd2cWCCH0=",
-    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
-    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
-    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
-    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
-    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
-    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
-    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
-    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
-    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
-    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
+    "h1:LF8arSzHfhbyQSFtTMTYEqCM34klzrbAQBJMHYCs9d8=",
+    "zh:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac",
+    "zh:65b7f9799b88464d9c2ec529713b7f52ea744275b61a8dc86cdedab1b2dcb933",
+    "zh:80d3e9c95b7b4ae7c54005cd127cae82e5c53d2b7023ef24c147337bac9dadd9",
+    "zh:841b60c07683e4bf456799ccd718896fdafdcc2c49252ae09967f2e74d8c8a03",
+    "zh:8fa1c592a9c78222e35713c6edb3f1f818a4c6f3524a30a209f0a7e919827b68",
+    "zh:bb795cc1429e09466840c09d39a28edf1db5070b1ec76822fc1173906a264572",
+    "zh:da1784818a89bea29dfe660632f0060a7a843e4e564d74435fbeca002b0f7d2a",
+    "zh:f409bf21b1cdaa6dac47cd79806f3d93f67e9507fe4dbf33b0165335f53bc2e1",
+    "zh:fbea7a1ff84b430ba9594698e93196d81d03e4036de3d1cafccb2a96d5b38581",
+    "zh:fbf0c84663a7e85881388d7d71ac862184f05fbf2d17ecf76bc5d3d7503ea260",
   ]
 }
 
@@ -132,6 +109,24 @@ provider "registry.opentofu.org/hashicorp/random" {
     "zh:ba396849f0f6d488784f6039095634e1c84e67e31375f3d17218fcf8ce952cb8",
     "zh:cb695db8798957bd64ce411f061307e39cb2baa69668b4d42ccf010db47d2e39",
     "zh:d02704bf99a93dc0b1ca00bd6051df9c431fbe17cd662a1ab58db1b96264a26f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/tls" {
+  version     = "4.0.5"
+  constraints = "4.0.5"
+  hashes = [
+    "h1:zEH0OgSkeXDqNWzmOUWDczrUwyyujAHvnbW79qdxVMI=",
+    "zh:05a7dc3ac92005485714f87541ad6d0d478988b478c5774227a7d39b01660050",
+    "zh:547e0def44080456169bf77c21037aa6dc9e7f3e644a8f6a2c5fc3e6c15cf560",
+    "zh:6842b03d050ae1a4f1aaed2a2b1ca707eae84ae45ae492e4bb57c3d48c26e1f1",
+    "zh:6ced0a9eaaba12377f3a9b08df2fd9b83ae3cb357f859eb6aecf24852f718d9a",
+    "zh:766bcdf71a7501da73d4805d05764dcb7c848619fa7c04b3b9bd514e5ce9e4aa",
+    "zh:84cc8617ce0b9a3071472863f43152812e5e8544802653f636c866ef96f1ed34",
+    "zh:b1939e0d44c89315173b78228c1cf8660a6924604e75ced7b89e45196ce4f45e",
+    "zh:ced317916e13326766427790b1d8946c4151c4f3b0efd8f720a3bc24abe065fa",
+    "zh:ec9ff3412cf84ba81ca88328b62c17842b803ef406ae19152c13860b356b259c",
+    "zh:ff064f0071e98702e542e1ce00c0465b7cd186782fe9ccab8b8830cac0f10dd4",
   ]
 }
 

--- a/hosts.tf
+++ b/hosts.tf
@@ -32,7 +32,7 @@ module "nixos_install" {
   instance_id = hcloud_server.cluster_hosts[each.key].id
 
   # this being marked as sensitive hides all output from nixos-anywhere, but that does not print the private key so this is fine
-  install_ssh_key = nonsensitive(sshkey_ed25519_key_pair.bootstrap.private_key_pem)
+  install_ssh_key = nonsensitive(tls_private_key.bootstrap.private_key_pem)
   install_user    = "root"
 
   target_user = var.ssh_user
@@ -62,13 +62,13 @@ resource "cloudflare_record" "server_wildcard" {
   value   = hcloud_server.cluster_hosts[each.key].ipv4_address
 }
 
-resource "sshkey_ed25519_key_pair" "bootstrap" {
-  comment = "dsekt-infra-boostrap"
+resource "tls_private_key" "bootstrap" {
+  algorithm = "ED25519"
 }
 
 resource "hcloud_ssh_key" "bootstrap" {
   name       = "dsekt-infra-bootstrap"
-  public_key = sshkey_ed25519_key_pair.bootstrap.public_key
+  public_key = tls_private_key.bootstrap.public_key_openssh
 }
 
 # This should depend on everything that's needed for the nomad cluster to be ready for getting it's

--- a/hosts.tf
+++ b/hosts.tf
@@ -14,6 +14,9 @@ resource "hcloud_server" "cluster_hosts" {
   image       = "debian-12"
   server_type = each.value.server_type
   ssh_keys    = [hcloud_ssh_key.bootstrap.id]
+  lifecycle {
+    ignore_changes = [ ssh_keys ]
+  }
   network {
     network_id = hcloud_network.cluster.id
     ip         = each.value.private_ip_addr

--- a/main.tf
+++ b/main.tf
@@ -24,9 +24,9 @@ terraform {
       source  = "hashicorp/random"
       version = "3.6.1"
     }
-    sshkey = {
-      source  = "daveadams/sshkey"
-      version = "0.2.1"
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.5"
     }
   }
   backend "s3" {


### PR DESCRIPTION
The current provider, `daveadams/sshkey`, does not have a GPG key uploaded to OpenTofu's registry (only registry.terraform.io), so it fails signature validation. In any case, a Hashicorp-maintained provider seems more reliable.