### PR TITLE
postgres: allow wheel users to auth to pg as any db user

### DIFF
--- a/profiles/postgres.nix
+++ b/profiles/postgres.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, lib, ... }:
 {
   services.postgresql = {
     enable = true;
@@ -7,6 +7,18 @@
     authentication = ''
       host all all ${config.dsekt.addresses.subnet} md5
       host all all 172.16.0.0/12 md5 # allow connections from docker (well, all class C private networks)
+
+      local all all      peer map=m
+    '';
+    # Allow all unix users in the group `wheel` to authenticate as any database
+    # user. (Since they can become root this is only for convenience). Also
+    # allow any unix user to authenticate as the database user with the same
+    # name, which is the case by default, but not when you add this `identMap`.
+    identMap = ''
+      ${lib.concatMapStringsSep "\n" (name: ''
+        m ${name} all
+      '') config.users.groups.wheel.members}
+      m /^(.*)$ \1
     '';
     settings = {
       max_connections = 400;


### PR DESCRIPTION
NOTE: Requires postgres 16, but `main` is currently on postgres 15.

Allows users in the `wheel` group to authenticate to postgres as any user, while not removing the normal peer authentication ability.
A basically identical setup works for me on my machines (that run postgres 16).

Makes e.g. `psql -U sso` work.