### PR TITLE
Add an ssh proxy to drifvarkaden

### DIFF
--- a/hosts/hades.nix
+++ b/hosts/hades.nix
@@ -34,13 +34,12 @@
         endpoint = "mjukglass.datasektionen.se:51800";
         presharedKeyFile = config.age.secrets.wireguard-preshared-key.path;
         publicKey = "QszePOBh9UBg8v4BNHkY4ZeqBfiLXr5uwDVjTSRqHX0=";
-        allowedIPs = [ "10.83.1.1/32" ];
+        allowedIPs = [ "${config.dsekt.addresses.hosts.mjukglass}/32" ];
       }
       {
-        # drifvarkaden
         presharedKeyFile = config.age.secrets.wireguard-preshared-key.path;
         publicKey = "9O+wjIbvxZq3sVk6gxfoI4jhSCfPOte0dWnMbG3obT0=";
-        allowedIPs = [ "10.83.1.2/32" ];
+        allowedIPs = [ "${config.dsekt.addresses.hosts.drifvarkaden}/32" ];
       }
     ];
   };

--- a/modules/addresses.nix
+++ b/modules/addresses.nix
@@ -23,6 +23,7 @@ in
       artemis = "10.83.0.6";
 
       mjukglass = "10.83.1.1";
+      drifvarkaden = "10.83.1.2";
 
       self = self.${config.networking.hostName};
     });

--- a/profiles/traefik-external.nix
+++ b/profiles/traefik-external.nix
@@ -30,7 +30,7 @@
 
       entryPoints.mattermost-calls-tcp.address = ":8443/tcp";
       entryPoints.mattermost-calls-udp.address = ":8443/udp";
-      entryPoints.drifvarkaden-ssh.address = ":2269/tcp";
+      entryPoints.drifvarkaden-ssh.address = ":220/tcp";
 
       certificatesresolvers.default.acme = {
         # Good for testing: caserver = "https://acme-staging-v02.api.letsencrypt.org/directory";
@@ -61,7 +61,16 @@
         };
         serversTransports.nomadTransport.rootCAs = "${../files/nomad-agent-ca.pem}";
       };
-      tcp.
+      tcp = {
+        routers.drifvarkaden-ssh = {
+          entryPoints = [ "drifvarkaden-ssh" ];
+          rule = "HostSNI(`*`)";
+          service = "drifvarkaden-ssh";
+        };
+        services.drifvarkaden-ssh.loadBalancer = {
+          servers = [ { address = "drifvarkaden.dsekt.internal:22"; } ];
+        };
+      };
       tls.stores.default.defaultGeneratedCert = {
         resolver = "default";
         domain = {
@@ -75,6 +84,7 @@
     80
     443
     8443
+    220
   ];
   networking.firewall.allowedUDPPorts = [ 8443 ];
 

--- a/profiles/traefik-external.nix
+++ b/profiles/traefik-external.nix
@@ -14,8 +14,6 @@
       (pkgs.writeText "traefik-cloudflare-config" "CLOUDFLARE_EMAIL=d-sys@datasektionen.se")
     ];
     staticConfigOptions = {
-      entryPoints.mattermost-calls-tcp.address = ":8443/tcp";
-      entryPoints.mattermost-calls-udp.address = ":8443/udp";
       entryPoints.web = {
         address = ":443";
         asDefault = true;
@@ -29,6 +27,10 @@
           permanent = "true";
         };
       };
+
+      entryPoints.mattermost-calls-tcp.address = ":8443/tcp";
+      entryPoints.mattermost-calls-udp.address = ":8443/udp";
+      entryPoints.drifvarkaden-ssh.address = ":2269/tcp";
 
       certificatesresolvers.default.acme = {
         # Good for testing: caserver = "https://acme-staging-v02.api.letsencrypt.org/directory";
@@ -59,6 +61,7 @@
         };
         serversTransports.nomadTransport.rootCAs = "${../files/nomad-agent-ca.pem}";
       };
+      tcp.
       tls.stores.default.defaultGeneratedCert = {
         resolver = "default";
         domain = {


### PR DESCRIPTION
Drifvarkaden is the arcade game in meta. It's behind a NAT but should be reachable through the wireguard proxy (didn't work now when I tested so I assume it's off).

I'm not incredibly happy that this is located where it is but I don't really know how to improve it.

I pointed it to `poseidon.dsekt.internal:22` when testing and that worked.