### PR TITLE
Refactor GitHub deploy tokens

### DIFF
--- a/nomad.tf
+++ b/nomad.tf
@@ -47,10 +47,10 @@ resource "nomad_job" "vault" {
 }
 
 resource "nomad_variable" "jobs_vault" {
-  path = "nomad/jobs/vault"
+  path      = "nomad/jobs/vault"
   namespace = "vault"
   items = {
-    db_password = var.vault_db_password
+    db_password   = var.vault_db_password
     smtp_username = aws_iam_access_key.vaultwarden_smtp.id
     smtp_password = aws_iam_access_key.vaultwarden_smtp.ses_smtp_password_v4
   }
@@ -69,7 +69,7 @@ resource "nomad_job" "twenty" {
 # Auth
 
 resource "nomad_namespace" "auth" {
-  name = "auth"
+  name        = "auth"
   description = "Contains jobs that provide auth{entication,orization} for other jobs"
 }
 


### PR DESCRIPTION
It... looks like it gives the same result as before but I'm not 100% sure. But worst case is that a repo isn't allowed to deploy so it wouldn't be catastrophic.

I think it looks nicer now and deploying a new repo only requires adding one more line in here (rather than copying 6 lines and changing the name at two places) which seems like a nice idea.