### PR TITLE
MediaWiki: init

### DIFF
--- a/.github/workflows/tofu-plan.yml
+++ b/.github/workflows/tofu-plan.yml
@@ -46,3 +46,4 @@ jobs:
             hcloud_token = "${{ secrets.TF_HCLOUD_TOKEN }}"
             cloudflare_api_token = "${{ secrets.TF_CLOUDFLARE_TOKEN }}"
             vault_db_password = "${{ secrets.TF_VAULT_DB_PASSWORD }}"
+            nomad_sso_client_secret = "${{ secrets.TF_NOMAD_SSO_CLIENT_SECRET }}"

--- a/hosts/ares.nix
+++ b/hosts/ares.nix
@@ -13,6 +13,7 @@
     nomad.client
     postgres
     traefik-external
+    mediawiki
   ];
 
   dsekt.nomad.volumes.host.mattermost = {

--- a/modules/restic.nix
+++ b/modules/restic.nix
@@ -27,7 +27,7 @@
     };
 
     backupPrepareCommand = lib.mkOption {
-      type = with lib.types; nullOr str;
+      type = with lib.types; nullOr lines;
       default = null;
       description = lib.mdDoc ''
         Script to run before starting the backup process.

--- a/profiles/dns.nix
+++ b/profiles/dns.nix
@@ -63,6 +63,7 @@ in
 
         postgres   CNAME ares
         ldap-proxy CNAME mjukglass
+        mediawiki  CNAME ares
       '';
       allowQuery = allowedNetworks;
     };

--- a/profiles/mediawiki.nix
+++ b/profiles/mediawiki.nix
@@ -1,0 +1,97 @@
+{
+  config,
+  secretsDir,
+  pkgs,
+  ...
+}:
+let
+  internalHostname = "mediawiki.dsekt.internal";
+in
+{
+  services.mediawiki = {
+    enable = true;
+    url = "https://wiki.datasektionen.se";
+    name = "Datasektionen Wiki";
+    extensions = {
+      # NOTE: these links disappear if they change the commit hash for a version or remove a
+      # version. Check <https://extdist.wmflabs.org/dist/extensions/> and take the latest (or
+      # something) version if this ever breaks. They do however get cached pretty well since we
+      # specify the hash so it should take a while before it breaks (which is even worse).
+      OpenIDConnect = pkgs.fetchzip {
+        url = "https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_44-3c18370.tar.gz";
+        hash = "sha256-X5kUuvxINbuXaLMKRcLOl2L3qbnMT72lg2NA3A9Daj8=";
+      };
+      PluggableAuth = pkgs.fetchzip {
+        url = "https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_44-1a117ee.tar.gz";
+        hash = "sha256-YHUek3pEM9XH2YLLkbfqEbPHMJBEzKGmJEin7eW91/g=";
+      };
+      VisualEditor = null;
+    };
+    extraConfig = ''
+      $wgPluggableAuth_EnableAutoLogin = true;
+      $wgPluggableAuth_Config[] = [
+        "plugin" => "OpenIDConnect",
+        "data" => [
+          "providerURL" => "https://sso.datasektionen.se/op",
+          "clientID" => "wiki",
+          "clientsecret" => trim(file_get_contents("${config.age.secrets.mediawiki-sso-client-secret.path}")),
+          "scope" => ["openid", "profile", "email", "pls_wiki"],
+        ],
+        "groupsyncs" => [
+          [
+            "type" => "mapped",
+            "map" => [
+              "bureaucrat" => [ "pls_wiki" => "bureaucrat" ], // jag ÄLSKAR byråkrati
+            ],
+          ]
+        ],
+      ];
+      $wgOpenIDConnect_UseRealNameAsUserName = true;
+
+      // $wgDebugToolbar = true;
+    '';
+    passwordSender = "d-sys@datasektionen.se";
+    webserver = "nginx";
+    nginx.hostName = internalHostname;
+    passwordFile = config.age.secrets.mediawiki-password.path;
+  };
+
+  services.nginx.virtualHosts.${internalHostname} = {
+    listen = [
+      {
+        addr = config.dsekt.addresses.hosts.self;
+        port = 3141;
+      }
+    ];
+    extraConfig = ''
+      absolute_redirect off;
+    '';
+  };
+
+  # TODO: this only works when this is running on the same server as profiles.traefik-external
+  services.traefik.dynamicConfigOptions.http = {
+    routers.mediawiki = {
+      rule = "Host(`wiki.datasektionen.se`)";
+      service = "mediawiki";
+      tls.certresolver = "default";
+    };
+    services.mediawiki.loadBalancer = {
+      servers = [ { url = "http://${internalHostname}:3141"; } ];
+    };
+  };
+
+  # TODO: backup uploads dir & mysql database
+
+  age.secrets.mediawiki-sso-client-secret = {
+    file = secretsDir + "/mediawiki-sso-client-secret.age";
+    owner = "mediawiki";
+    group = "nogroup";
+    mode = "400";
+  };
+  age.secrets.mediawiki-password = {
+    file = secretsDir + "/mediawiki-password.age";
+    owner = "mediawiki";
+    group = "nogroup";
+    mode = "400";
+  };
+}

--- a/profiles/mediawiki.nix
+++ b/profiles/mediawiki.nix
@@ -83,7 +83,7 @@ in
   dsekt.restic = {
     # TODO: not sure if this works
     backupPrepareCommand = ''
-      ${pkgs.sudo}/bin/sudo -u mysql ${pkgs.mysql}/bin/mysqldump --all-databases > /root/mysql_dump.sql
+      ${pkgs.sudo}/bin/sudo -u mysql ${config.services.mysql.package}/bin/mysqldump --all-databases > /root/mysql_dump.sql
     '';
 
     paths = [

--- a/profiles/mediawiki.nix
+++ b/profiles/mediawiki.nix
@@ -68,7 +68,7 @@ in
     '';
   };
 
-  # TODO: this only works when this is running on the same server as profiles.traefik-external
+  # WARN: this only works when this is running on the same server as profiles.traefik-external
   services.traefik.dynamicConfigOptions.http = {
     routers.mediawiki = {
       rule = "Host(`wiki.datasektionen.se`)";
@@ -80,7 +80,17 @@ in
     };
   };
 
-  # TODO: backup uploads dir & mysql database
+  dsekt.restic = {
+    # TODO: not sure if this works
+    backupPrepareCommand = ''
+      ${pkgs.sudo}/bin/sudo -u mysql ${pkgs.mysql}/bin/mysqldump --all-databases > /root/mysql_dump.sql
+    '';
+
+    paths = [
+      config.services.mediawiki.uploadsDir
+      "/root/mysql_dump.sql"
+    ];
+  };
 
   age.secrets.mediawiki-sso-client-secret = {
     file = secretsDir + "/mediawiki-sso-client-secret.age";

--- a/profiles/mediawiki.nix
+++ b/profiles/mediawiki.nix
@@ -19,11 +19,11 @@ in
       # specify the hash so it should take a while before it breaks (which is even worse).
       OpenIDConnect = pkgs.fetchzip {
         url = "https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_44-3c18370.tar.gz";
-        hash = "sha256-X5kUuvxINbuXaLMKRcLOl2L3qbnMT72lg2NA3A9Daj8=";
+        hash = "sha256-3QwCgql8dPTzfS0jf9dhvLb9dbzD7JWWNsH2QhrrzL4=";
       };
       PluggableAuth = pkgs.fetchzip {
         url = "https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_44-1a117ee.tar.gz";
-        hash = "sha256-YHUek3pEM9XH2YLLkbfqEbPHMJBEzKGmJEin7eW91/g=";
+        hash = "sha256-TtU1z5+imZSbNS+7kE1g3ZJpnORNeX6eF8k++YpI6pg=";
       };
       VisualEditor = null;
     };

--- a/secrets/mediawiki-password.age
+++ b/secrets/mediawiki-password.age
@@ -1,0 +1,16 @@
+age-encryption.org/v1
+-> piv-p256 9aSbLw A6NbikQUxELfMgYWuwlqWxZkmyE5n6NPN5btP2ejGNHv
+CrSvM1FXQRN5GBuQcMGRT6Da4oKHFwLnM5X4kc3tLEg
+-> piv-p256 Ddzw4A Aty4x+/ovnWQZMyL87ZGyOBKgB2l6Y85d1I6iIxhDH1B
+HXAxgrELZeVXljfEFsjfFxQ0owiRKW+uFxbsm3O6DUs
+-> ssh-ed25519 LypaQg FBE+IT5ntkh0PupVTfYNgXjn2ieQhnx025cy4ZMoqjs
+yCA5icRZme6BgaF9QcK8clcuGqRUppRpEwhSiUGK7lk
+-> ssh-ed25519 ic5tvw 0fYcIUvZkCp/34zQg4WiYyhxE+12+nffRU3aJ37ujDM
+46GEw7blCSOge4WIZJfzPwCVCenfsccwebcYo7GiCwg
+-> ssh-ed25519 Wy7Ldw o+1EOfI4slxUIH4epITwIl3AhTggL8LC3b/oTcZFRxc
+yAj7eyukvy5tV4QsfQ/WrHswPmH+eurKQr9zcrnxB8I
+--- jB68nX0B0ud1Tvk68crNzHMh1dlIzl0mBX+bXoBcAAU
+nåÄé–Ü›b5îEÆI
+HZñ¦—–ýµ
+"ŽóÐþ”õþ)€)-‰2<A
+`H6¬o&íÄ™Þi¨þMsž#òÖ

--- a/secrets/mediawiki-sso-client-secret.age
+++ b/secrets/mediawiki-sso-client-secret.age
@@ -1,0 +1,13 @@
+age-encryption.org/v1
+-> piv-p256 9aSbLw A+ZTkoesRTn8Q9qk+vdwSHuV4AD5SNjPgQlb5T2fgIDY
+bgEpJDfpJ9d3ngVOE9+/dWH/2v2obZmuo/Uxbr5G6Go
+-> piv-p256 Ddzw4A AqPM0Yl327c7ACsGAXeKFFnrldG4F7Ytefd5dg8bXTUW
+5OMTLF/x+0GmV4QhF2Cfi5YeGgyl0R1MMmgRuLpmzhg
+-> ssh-ed25519 LypaQg vfdUu/JQq+mDm29EXacXK5OjjDVnS6CRnb4wqAx+XT0
+XURX90bvQr1vW6bGqb8BY5B5wQs3s8aOfiqdmjPtW5M
+-> ssh-ed25519 ic5tvw xyuF/ho48hteFysrQ9p13SVoGwMEIHn5M79phsU9738
+gMCLpv6dxC4TnT/DlBOh8XLX6cX0SP8XrA1cPQ7Xdvs
+-> ssh-ed25519 Wy7Ldw YVNPmxerNhz18AWY+KaXAmuiHKIoW/MLY7ucu54Hyks
+ydRMh9CJkgPi87cuABO+A2psrByCaIFs7IdozsN1+7Y
+--- rCLfzRdM4/npoHZRLEN/NfoZwUeTX00PO8ynMesBO/c
+WςΠAu\•^J(Ώ΅‹άD΄4χρ£=μ€Λη'aµ‰άφ@Z,δW£ΌIrΎΑ’ή|ί½Φ²=ζQΘ’-gΡ¬JΦιΣ

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -49,4 +49,9 @@ in
   # { "auths": { "ghcr.io": { "auth": "$(echo $username:$password | base64)" } } }
   # Password is a personal access token (classic) with `read:packages`.
   "nomad-docker-auth.json.age".publicKeys = sysadmins ++ nomadClients;
+
+  # Plain text format
+  "mediawiki-sso-client-secret.age".publicKeys = sysadmins ++ [ ares ];
+  # This is not even usable since you can't login with username/password with the OIDC plugin, but it is required. Plain text format
+  "mediawiki-password.age".publicKeys = sysadmins ++ [ ares ];
 }


### PR DESCRIPTION
Installs a MediaWiki instance with login through SSO. It currently only works when deployed to ares, since it must run on the same server as the external traefik instance to configure it through a file.