### PR TITLE
fix(meta-tv): Configure backup DNS

### DIFF
--- a/hosts/meta-tv.nix
+++ b/hosts/meta-tv.nix
@@ -78,7 +78,10 @@
   programs.hyprland.enable = true;
   xdg.portal.enable = true;
   xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-hyprland ];
-  environment.systemPackages = with pkgs; [ alacritty git ];
+  environment.systemPackages = with pkgs; [
+    alacritty
+    git
+  ];
 
   # Configure Swedish keyboard layout for TTYs.
   console.keyMap = "sv-latin1";
@@ -154,6 +157,44 @@
     inherit (config.services.cloudflare-ddns) group;
     owner = config.services.cloudflare-ddns.user;
     mode = "0440";
+  };
+
+  # Ensure that the nomad service doesn't start until the WireGuard interface is
+  # up.
+  systemd.services.nomad = {
+    after = [
+      "network-online.target"
+      "wg-quick-wg-dsekt.service"
+    ];
+    wants = [
+      "network-online.target"
+      "wg-quick-wg-dsekt.service"
+    ];
+    serviceConfig.ExecStartPre =
+      let
+        waitForWgDsekt = pkgs.writeShellScript "wait-for-wg-dsekt" ''
+          set -eu
+
+          for _ in $(${pkgs.coreutils}/bin/seq 1 60); do
+            if ${pkgs.iproute2}/bin/ip link show dev wg-dsekt up >/dev/null 2>&1; then
+              latest_handshake="$(${pkgs.wireguard-tools}/bin/wg show wg-dsekt latest-handshakes \
+                | ${pkgs.gawk}/bin/awk '($2 > max) { max = $2 } END { print max + 0 }')"
+
+              if [ "$latest_handshake" -gt 0 ]; then
+                exit 0
+              fi
+            fi
+
+            ${pkgs.coreutils}/bin/sleep 2
+          done
+
+          echo "wg-dsekt did not establish a WireGuard handshake in time" >&2
+          exit 1
+        '';
+      in
+      [
+        waitForWgDsekt
+      ];
   };
 
   ## Hardware configuration

--- a/hosts/meta-tv.nix
+++ b/hosts/meta-tv.nix
@@ -52,6 +52,12 @@
   # Force the configured password to be used.
   users.mutableUsers = false;
 
+  environment.etc."resolv.conf".text = lib.mkForce ''
+    nameserver ${config.dsekt.addresses.hosts.self}
+    nameserver 1.1.1.1
+    options edns0
+  '';
+
   networking.wg-quick.interfaces.wg-dsekt = {
     address = [ "10.83.1.3/32" ];
     privateKeyFile = config.age.secrets.wireguard-meta-tv-private-key.path;


### PR DESCRIPTION
Adds 1.1.1.1 as a backup DNS server to `resolve.conf` for META-TV. This seems to fix the issue where the machine can't establish the initial connection to the WireGuard network.

My understanding of the issue is that at startup the machine isn't connected to the Hades WireGuard network, meaning that it can't connect to the configure DNS server 10.83.1.3, which is located on that private network. But the machine needs to make a DNS lookup for hades.datasektionen.se to connect to the WireGuard network, which of course isn't possible since it's not connected to the WireGuard network yet.

Adding `1.1.1.1` as a backup network fixes this since now the initial lookup for hades.datasektionen.se can be done before the machine has been connected to Hades.

It's very possible that I'm missing something though. :sweat_smile: