### PR TITLE
feat(meta-tv): Hide cursor after timeout

### DIFF
--- a/hosts/meta-tv.nix
+++ b/hosts/meta-tv.nix
@@ -119,6 +119,10 @@
       kb_layout = se
     }
 
+    cursor {
+      inactive_timeout = 5
+    }
+
     # Use orange Catppuccin unicat wallpaper. :)
     # It is MIT licensed, so it should be fine.
     exec-once = ${pkgs.swaybg}/bin/swaybg --mode fill --image ${


### PR DESCRIPTION
Configures the mouse cursor to be hidden after it's not moved for 5 seconds to META-TV's Hyprland configuration.